### PR TITLE
arreglo_algunas_cosas_vista_profiles_company_y_vista_empleos

### DIFF
--- a/client/src/components/CardEmpleo/CardEmpleo.jsx
+++ b/client/src/components/CardEmpleo/CardEmpleo.jsx
@@ -4,34 +4,33 @@ import { FaMedal } from 'react-icons/fa'
 import style from './CardEmpleo.module.css';
 
 const CardEmpleo = (props) => {
-
 return (
         <Link className={style.words} to={`/empleoDetail/${props.id}`}>
             <div className={style.mainContainer}>
                 <div className={style.containerInfo}>
-                    {/* <img className={style.image} src={props.logo} alt="logo" /> */}
+                    <img className={style.image} src={props.logo} alt="logo" />
                     <h2 className={style.temps} >{props.title}</h2>
                     <p className={style.description} >{props.description}</p>
                 </div>
                 <div className={style.containerView}>
                     <div className={style.containerIcons}>
-                        <div>
+                        <div className={style.detailIcons}>
                             <BsBuildings className={style.icons}/>
                         </div>
                         <div className={style.containerText}>
-                            <p className={style.text}>{props.WorkMethodId}</p>
+                            <p className={style.text}>{props.WorkMethod}</p>
                         </div>   
                     </div>
                     <div className={style.containerIcons}>
                         <BsStopwatch className={style.icons}/>
                         <div className={style.containerText}>
-                            <p className={style.text}>{props.WorkMethodId}</p>
+                            <p className={style.text}>{props.Workday}</p>
                         </div> 
                     </div>
                     <div className={style.containerIcons}>
                         <FaMedal className={style.icons}/>
                         <div className={style.containerText}>
-                            <p className={style.text}>{props.WorkMethodId}</p>
+                            <p className={style.text}>{props.Seniority}</p>
                         </div> 
                     </div>
                 </div>

--- a/client/src/components/CardEmpleo/CardEmpleo.module.css
+++ b/client/src/components/CardEmpleo/CardEmpleo.module.css
@@ -1,7 +1,7 @@
 .mainContainer {
     border-radius: 10px;
-    width: 50vw;
-    height: 18vh;
+    width: 57vw;
+    height: 33vh;
     display: flex;
     margin-top: 3px;
     margin-bottom: 7px;
@@ -66,9 +66,9 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 3vw;
-    height: 2vh;
-    margin: 1vh 0.4vw;
+    width: fit-content;
+    height: 4vh;
+    margin-left: 20%;
 }
 
 .containerText {
@@ -90,9 +90,21 @@
     align-items: flex-end;
 }
 
+.icons{
+    margin-top: 5%;
+}
+
+
+.textIcons{
+    margin-left: 3%;
+}
+
 .identification {
     width: 100%;
     height: 30%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     font-size: 90%;
     font-weight: bold;
     text-decoration: none;

--- a/client/src/components/CardsContainerEmpleo/CardsContainerEmpleo.jsx
+++ b/client/src/components/CardsContainerEmpleo/CardsContainerEmpleo.jsx
@@ -6,7 +6,7 @@ import Page from "../Paginated/Page";
 
 const CardsContainerEmpleo = ({ vacants }) => {
     const [currentPage, setCurrentPage] = useState(1);
-    const [vacantsPerPage, /* setVacantsPerPagePerPage */] = useState(5);
+    const [vacantsPerPage, /* setVacantsPerPagePerPage */] = useState(20);
     const indexOfLastCharacter = currentPage * vacantsPerPage;
     const indexOfFirstCharacter = indexOfLastCharacter - vacantsPerPage;
 
@@ -23,7 +23,7 @@ const CardsContainerEmpleo = ({ vacants }) => {
             setCurrentPage(newPage);
     }
     }, [currentVacants, vacants, vacantsPerPage]);
-
+console.log(vacants);
     return (
         <div className={style.mainContainer}>
             <Page
@@ -34,13 +34,20 @@ const CardsContainerEmpleo = ({ vacants }) => {
             <div className={style.cardsContainer}>
                 {
                     currentVacants?.map(vacancy => {
+                        let truncatedDescription = vacancy.description.slice(0, 200);
+                            if (vacancy.description.length > 200) {
+                                 truncatedDescription += ' . . . ';
+                                 }
                         return (
                             <Card
                                 key={vacancy.id}
                                 id={vacancy.id}
                                 // logo={vacancy.logo}
                                 title={vacancy.title}
-                                description={vacancy.description}
+                                description={truncatedDescription}
+                                Workday={vacancy.Workday.name}
+                                WorkMethod={vacancy.WorkMethod.name}
+                                Seniority={vacancy.Seniority.name}
                             />
                         )
                     })

--- a/client/src/components/CardsContainerEmpleo/CardsContainerEmploes.module.css
+++ b/client/src/components/CardsContainerEmpleo/CardsContainerEmploes.module.css
@@ -3,9 +3,8 @@
     flex-direction: column;
     align-items: center;
     width: 63vw;
-    height: 84vh;
+    height: 100vh;
     justify-content: flex-start;
-    margin-top: 2vh;
 }
 
 
@@ -18,9 +17,9 @@
     gap: 1em;
     padding: 20px;
     overflow-y: scroll;
-    height: 89vh;
+    min-height: 92vh;
     justify-content: flex-start;
-    overflow: hidden;
+  
 }
 
 @media (max-width: 768px) {

--- a/client/src/components/CardsProfilesCompany/CardsProfilesCompany.jsx
+++ b/client/src/components/CardsProfilesCompany/CardsProfilesCompany.jsx
@@ -6,32 +6,29 @@ import { Link } from "react-router-dom";
 import { GiWorld } from "react-icons/gi";
 
 
-const CardProfileCompany = ({ id, logo, business_name, description, work_sector, name, country, cuit, email, web }) => {
+const CardProfileCompany = ({ id, logo, business_name, description, job_area, name, country, cuit, email, photo, web }) => {
    
 
 
   return (
         <div className={style.mainContainer} >
         <div className={style.containerImgEmpresa}>
-        {/* <img className={style.img} variant="top" src={photo}/> */}
-        <img className={style.img} variant="top" src="https://henry-social-resources.s3-sa-east-1.amazonaws.com/LOGO-REDES-01_og.jpg"/>
+        <img className={style.img} variant="top" src={photo}/>
         </div>
         <Card.Body >
           <Card.Title className={style.title}>{business_name}</Card.Title>
-          {/* <Card.Text className={style.text}>{description}</Card.Text> */}
-          <Card.Text className={style.text}>La mejor empresa de todo el mundo, ven y trabaja con nosotros, la pasaras genial y con un sueldo impresionante</Card.Text>
+          <Card.Text className={style.text}>{description}</Card.Text>
         </Card.Body>
         <ListGroup className={style.infoContainer}>
         <ListGroup.Item className={style.item}>Sector de trabajo: Tecnológico </ListGroup.Item>
-          {/* <ListGroup.Item className={style.item}>Sector de trabajo: {work_sector} </ListGroup.Item> */}
+          <ListGroup.Item className={style.item}>Sector de trabajo: {job_area} </ListGroup.Item>
           <ListGroup.Item className={style.item}>País: {country}</ListGroup.Item>
           <ListGroup.Item className={style.item}>CUIT : {cuit}</ListGroup.Item>
           <ListGroup.Item className={style.item}>Reclutador: {name}</ListGroup.Item>
         </ListGroup>
         <Card.Body className={style.containerWeb}>
-          {/* <Link to={web}> */}
           <ListGroup.Item className={style.item}>Sitio Web:</ListGroup.Item>
-          <Link to="https://www.soyhenry.com/">
+          <Link to={web}>
           <GiWorld className={style.linkedin}/>
           </Link>
           </Card.Body>

--- a/client/src/components/CardsProfilesCompany/CardsProfilesCompany.module.css
+++ b/client/src/components/CardsProfilesCompany/CardsProfilesCompany.module.css
@@ -1,6 +1,11 @@
 
 .mainContainer{
-    height: 110vh;
+    background-color: aqua;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 85vh;
     width: 30vw;
     border-radius: 0 15%;
     border: 5px solid var(--battleship-gray);
@@ -9,35 +14,30 @@
 }
 
 .infoContainer{
-    margin-top: 5%;
+  
     margin-bottom: 5%;
-    height: auto;
+    min-height: 20vh;
     border-top: 3px solid var(--battleship-gray);
     border-bottom: 3px solid var(--battleship-gray);
     border-radius: 0%;
+    height: fit-content;
+    width: fit-content;
 }
 
-.infoContainer2{
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin-top: 5%;
-    height: auto;
-    border-top: 3px solid var(--battleship-gray);
-    border-bottom: 3px solid var(--battleship-gray);
-    border-radius: 0%;
-}
 
 .img{
     width: 130px;
     height: 130px;
     border: 4px solid var(--oxford-blue);
     border-radius: 100%;
+    margin-left: 35%;
 }
 
 .title{
-    margin-top: 2%;
     color: var(--oxford-blue);
+    margin-bottom: 4%;
+    margin-top: 4%;
+
 }
 
 .title2{
@@ -46,12 +46,13 @@
     color: var(--oxford-blue);
 }
 
-.item{ 
+.item{
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 66%;
-    height: auto;
+    min-height: 10vh;  
+    min-width: 10vh;
     color: var(--oxford-blue);
 }
 

--- a/client/src/components/Filter/Filter.module.css
+++ b/client/src/components/Filter/Filter.module.css
@@ -6,7 +6,7 @@
     /* border: solid black 1px ; */
     border-radius: 7px;
     width: 25vw;
-    height: 60vh;
+    height: 68vh;
     background: #E1ECFC;
     margin-left: 3vw;
     margin-right: 3vw;
@@ -21,7 +21,8 @@
 .button {
     background-color: var(--battleship);
     width: 15vw;
-    height: 3.5vh;
+    height: 6vh;
+    margin-left: 15%;
 }
 
 .selectSpecial {

--- a/client/src/views/Empleos/Empleos.module.css
+++ b/client/src/views/Empleos/Empleos.module.css
@@ -5,6 +5,7 @@
     background: #1C1C1C;
     min-height: 100vh;
     overflow: hidden;
+    margin-top: 7%;
 }
 
 .filterAndCardsContainer {

--- a/client/src/views/ProfilesCompany/ProfilesCompany.jsx
+++ b/client/src/views/ProfilesCompany/ProfilesCompany.jsx
@@ -46,11 +46,13 @@ const ProfilesCompany = ({ setCurrentUserStore, setCurrentUserStore2 }) => {
     return (
         <div className={styles.container}>
             <NavBar setCurrentUserStore={setCurrentUserStore}/>
+            <div className={styles.page}>
             <Page
                 usersPerPage={companiesPerPage}
                 users={companies}
                 paginated={paginated}
             />
+            </div>
             {  isLoading ? (
                 <Loading/>
             ) : (
@@ -62,15 +64,15 @@ const ProfilesCompany = ({ setCurrentUserStore, setCurrentUserStore2 }) => {
                                         <CardProfileCompany
                                         key={compan.id}
                                         id={compan.id}
-                                        // logo={compan.logo}
+                                        photo={compan.photo}
                                         business_name={compan.business_name}
-                                        // description={compan.description}
-                                        // work_sector={compan.work_sector}
+                                        description={compan.description}
+                                        job_area={compan.job_area}
                                         name={compan.name}
                                         country={compan.country}
                                         cuit={compan.cuit}
                                         email={compan.email}
-                                        // web={compan.web}
+                                        web={compan.webPage}
                                         />
                                     </div>
                                 )

--- a/client/src/views/ProfilesCompany/ProfilesCompany.module.css
+++ b/client/src/views/ProfilesCompany/ProfilesCompany.module.css
@@ -14,3 +14,7 @@
     align-items: center;
     min-height: fit-content;
 }
+
+.page{
+    margin-top: 7%;
+}


### PR DESCRIPTION
Se eliminó la información hardcodeada de las cards de ProfilesCompany. 
Se agregaron las descripción en los íconos de las Cards de empleos para que muestre el seniority, si remoto o presencial y si es fulltime o parttime, se arregló la organización de la vista empleos que estaba rota, se cambió el número de cards a renderizar por página (20).